### PR TITLE
Fix for Xinterface not being found

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -9,7 +9,7 @@ mkdir "${PWD}"/SMF/
 mkdir "${PWD}"/SMF/META-INF/
 
 #Compile the binaries
-idlc "${PWD}"/idl/Xsmf.idl
+idlc -I /usr/share/idl/libreoffice "${PWD}"/idl/Xsmf.idl
 regmerge -v "${PWD}"/SMF/Xsmf.rdb UCR "${PWD}"/idl/Xsmf.urd
 rm "${PWD}"/idl/Xsmf.urd
 

--- a/idl/Xsmf.idl
+++ b/idl/Xsmf.idl
@@ -1,4 +1,4 @@
-#include </usr/share/idl/libreoffice/com/sun/star/uno/XInterface.idl>
+#include <com/sun/star/uno/XInterface.idl>
 
 module com { module smf { module ticker { module getinfo {
 


### PR DESCRIPTION
I tried to compile your extension on ubuntu 16.04 with Libre Office 5.1.2.2 and it's SDK. 

However when compiling I received this error on the idlc portion:

Compiling: idl/Xsmf.idl
/tmp/idli_E8hpNR: line 1: file '/usr/share/idl/libreoffice/com/sun/star/uno/XInterface.idl' not found

It is strange because the path and file name are absolutely correct. 

I found a workaround by specifying include path in the command and shortening the absolute path in the Xsmf.idl to a relative one.

The extension no longer has an issue compiling for me.
