### PR TITLE
Other Exchange Support

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -9,7 +9,7 @@ mkdir "${PWD}"/SMF/
 mkdir "${PWD}"/SMF/META-INF/
 
 #Compile the binaries
-idlc "${PWD}"/idl/Xsmf.idl
+idlc -I /usr/share/idl/libreoffice "${PWD}"/idl/Xsmf.idl
 regmerge -v "${PWD}"/SMF/Xsmf.rdb UCR "${PWD}"/idl/Xsmf.urd
 rm "${PWD}"/idl/Xsmf.urd
 

--- a/compile.sh
+++ b/compile.sh
@@ -9,7 +9,7 @@ mkdir "${PWD}"/SMF/
 mkdir "${PWD}"/SMF/META-INF/
 
 #Compile the binaries
-idlc -I /usr/share/idl/libreoffice "${PWD}"/idl/Xsmf.idl
+idlc "${PWD}"/idl/Xsmf.idl
 regmerge -v "${PWD}"/SMF/Xsmf.rdb UCR "${PWD}"/idl/Xsmf.urd
 rm "${PWD}"/idl/Xsmf.urd
 

--- a/idl/Xsmf.idl
+++ b/idl/Xsmf.idl
@@ -1,4 +1,4 @@
-#include </usr/share/idl/libreoffice/com/sun/star/uno/XInterface.idl>
+#include <com/sun/star/uno/XInterface.idl>
 
 module com { module smf { module ticker { module getinfo {
 

--- a/idl/Xsmf.idl
+++ b/idl/Xsmf.idl
@@ -6,9 +6,9 @@ module com { module smf { module ticker { module getinfo {
     {
       // Modeled as an 'any' to allow it to be NULL/None/Missing.
       any getYahoo( [in] string a, [in] any b );
-      any getMorningKey( [in] string a, [in] any b );
-      any getMorningFin( [in] string a, [in] any b );
-      any getMorningQFin( [in] string a, [in] any b );
+      any getMorningKey( [in] string a, [in] any b, [in] any c);
+      any getMorningFin( [in] string a, [in] any b, [in] any c );
+      any getMorningQFin( [in] string a, [in] any b, [in] any c );
       any getADVFN( [in] string a, [in] any b );
     };
 

--- a/idl/Xsmf.idl
+++ b/idl/Xsmf.idl
@@ -1,4 +1,4 @@
-#include <com/sun/star/uno/XInterface.idl>
+#include </usr/share/idl/libreoffice/com/sun/star/uno/XInterface.idl>
 
 module com { module smf { module ticker { module getinfo {
 

--- a/src/generate_metainfo.py
+++ b/src/generate_metainfo.py
@@ -33,7 +33,7 @@ desc_xml.write('  <dependencies>\n')
 desc_xml.write('    <OpenOffice.org-minimal-version value="2.4" d:name="OpenOffice.org 2.4"/>\n')
 desc_xml.write('  </dependencies>\n')
 desc_xml.write('  <identifier value="' + addin_id + '"/>\n')
-desc_xml.write('  <version value="' + addin_version + '"/>\n')   
+desc_xml.write('  <version value="' + addin_version + '"/>\n')
 desc_xml.write('  <display-name>\n')
 desc_xml.write('    <name lang="en">' + addin_displayname + '</name>\n')
 desc_xml.write('  </display-name>\n')
@@ -86,7 +86,7 @@ def define_function(xml_file, function_name, description, parameters):
 
     for p, desc in parameters:
         # Optional parameters will have a displayname enclosed in square brackets.
-        p_name = p.strip("[]")        
+        p_name = p.strip("[]")
         xml_file.write('          <node oor:name="' + p_name + '" oor:op="replace">\n')
         xml_file.write('            <prop oor:name="DisplayName">\n')
         xml_file.write('              <value xml:lang="en">' + p_name + '</value>\n')
@@ -112,16 +112,16 @@ define_function(smf_xml, \
     [('a', 'The ticker symbol.'), ('b', 'The data code.')])
 define_function(smf_xml, \
     'getMorningKey', \
-    'Fetches Morningstar Key Ratios (11yr).  a = "TICKER", b = "DATACODE"', \
-    [('a', 'The ticker symbol.'), ('b', 'The data code.')])
+    'Fetches Morningstar Key Ratios (11yr).  a = "TICKER", b = "DATACODE", c = "EXCHANGE"',  \
+    [('a', 'The ticker symbol.'), ('b', 'The data code.'), ('c', 'Optional Exchange')])
 define_function(smf_xml, \
     'getMorningFin', \
-    'Fetches Morningstar Financials (5yr).  a = "TICKER", b = "DATACODE"', \
-    [('a', 'The ticker symbol.'), ('b', 'The data code.')])
+    'Fetches Morningstar Financials (5yr).  a = "TICKER", b = "DATACODE", c = "EXCHANGE"' , \
+    [('a', 'The ticker symbol.'), ('b', 'The data code.'), ('c', 'Optional Exchange')])
 define_function(smf_xml, \
     'getMorningQFin', \
-    'Fetches Morningstar Quarterly Financials (5qtr).  a = "TICKER", b = "DATACODE"', \
-    [('a', 'The ticker symbol.'), ('b', 'The data code.')])
+    'Fetches Morningstar Quarterly Financials (5qtr).  a = "TICKER", b = "DATACODE",  c = "EXCHANGE"', \
+    [('a', 'The ticker symbol.'), ('b', 'The data code.'), ('c', 'Optional Exchange')])
 define_function(smf_xml, \
     'getADVFN', 'Fetches ADVFN Financial Data.  a = "TICKER", b = "DATACODE"', \
     [('a', 'The ticker symbol.'), ('b', 'The data code."')])

--- a/src/smf.py
+++ b/src/smf.py
@@ -34,7 +34,7 @@ import morningstar
 import advfn
 
 class SmfImpl(unohelper.Base, XSmf ):
-    """Define the main class for the SMF extension """    
+    """Define the main class for the SMF extension """
     def __init__( self, ctx ):
         self.ctx = ctx
         self.nyse_list = []
@@ -61,34 +61,36 @@ class SmfImpl(unohelper.Base, XSmf ):
             x = yahoo.fetch_data(self, ticker, datacode)
         return x
 
-    def getMorningKey( self, ticker, datacode):
+    def getMorningKey( self, ticker, datacode, exchange=None):
         """Return Keyratio data. Mapped to PyUNO through the Xsmf.rdb file"""
         try:
-            x = float(morningstar.fetch_keyratios(self, ticker, datacode))
+            x = float(morningstar.fetch_keyratios(self, ticker, datacode, exchange))
         except:
-            x = morningstar.fetch_keyratios(self, ticker, datacode)
+            x = morningstar.fetch_keyratios(self, ticker, datacode, exchange)
         return x
-    
-    def getMorningFin( self, ticker, datacode):
+
+    def getMorningFin( self, ticker, datacode, exchange=None):
         """Return Financial data. Mapped to PyUNO through the Xsmf.rdb file"""
         fin_type = ''
         try:
             x = float(morningstar.fetch_financials(self, fin_type, ticker,
-                                                    datacode))
+                                                    datacode, exchange))
         except:
-            x = morningstar.fetch_financials(self, fin_type, ticker, datacode)
+            x = morningstar.fetch_financials(self, fin_type, ticker,
+                                                    datacode, exchange)
         return x
-    
-    def getMorningQFin( self, ticker, datacode):
+
+    def getMorningQFin( self, ticker, datacode, exchange=None):
         """Return Quarterly data. Mapped to PyUNO through the Xsmf.rdb file"""
         fin_type = 'qtr'
         try:
             x = float(morningstar.fetch_financials(self, fin_type,  ticker,
-                                                    datacode))
+                                                    datacode, exchange))
         except:
-            x = morningstar.fetch_financials(self, fin_type, ticker, datacode)
+            x = morningstar.fetch_financials(self, fin_type, ticker, datacode,
+                                                    exchange)
         return x
-    
+
     def getADVFN( self, ticker, datacode):
         """Return ADVFN data. Mapped to PyUNO through the Xsmf.rdb file"""
         try:
@@ -96,7 +98,7 @@ class SmfImpl(unohelper.Base, XSmf ):
         except:
             x = advfn.fetch_advfn(self, ticker, datacode)
         return x
-    
+
 def find_exchange(self, ticker):
     """Determine exchange ticker is traded on for querying data providers"""
     exch_name = ['nasdaq','nyse','amex']
@@ -106,7 +108,7 @@ def find_exchange(self, ticker):
             if self.exchange_flag[0] == '0':
                     query_nasdaq(self, exch)
                     self.exchange_flag[0] = '1'
-            for i in self.nasdaq_list:                
+            for i in self.nasdaq_list:
                 if ticker == i[0]:
                     return 'XNAS'
         if exch == 'nyse':
@@ -151,7 +153,7 @@ def query_nasdaq(self, exch_name):
     elif exch_name == 'amex':
         self.amex_list = [row for row in exch_result]
     return 'Unknown Exception in query_nasdaq'
-    
+
 def createInstance( ctx ):
     return SmfImpl( ctx )
 

--- a/src/smftest.py
+++ b/src/smftest.py
@@ -27,15 +27,16 @@ cmd_folder = os.path.realpath(os.path.abspath
                               (os.path.split(inspect.getfile
                                              ( inspect.currentframe() ))[0]))
 if cmd_folder not in sys.path:
-    sys.path.insert(0, cmd_folder)  
+    sys.path.insert(0, cmd_folder)
 import smf
 
 def main(argv):
     main_smf = smf.SmfImpl(argv)
     arg_funct = ''
     arg_ticker = ''
+    arg_exchange = None
     try:
-        opts, args = getopt.getopt(argv, "f:t:",["function=","ticker="])
+        opts, args = getopt.getopt(argv, "f:t:e:",["function=","ticker="])
     except getopt.GetoptError:
         usage(2)
     for opt, arg in opts:
@@ -45,31 +46,37 @@ def main(argv):
             arg_funct = arg
         elif opt in ("-t", "--ticker"):
             arg_ticker = arg
+        elif opt == "-e":
+            arg_exchange = arg
     print ("Function tested is", arg_funct)
     print ("Ticker used is", arg_ticker)
+    if arg_exchange == None:
+        print ("Exchange: auto-lookup")
+    else:
+        print ("Exchange used is", arg_exchange)
     if arg_funct == "morningkey":
-        key_test(main_smf, arg_ticker)
+        key_test(main_smf, arg_ticker, arg_exchange)
     elif arg_funct == "morningfin":
-        fin_test(main_smf, arg_ticker, '')
+        fin_test(main_smf, arg_ticker, '', arg_exchange)
     elif arg_funct == "morningqfin":
-        fin_test(main_smf, arg_ticker, 'qtr')
+        fin_test(main_smf, arg_ticker, 'qtr', arg_exchange)
     elif arg_funct == "yahoo":
         yahoo_test(main_smf, arg_ticker)
     elif arg_funct == "advfn":
         advfn_test(main_smf, arg_ticker)
     sys.exit(2)
 
-def key_test(smf_py, ticker):
+def key_test(smf_py, ticker, exchange=None):
     test_data = []
     for d in range (1,948):
         test_data.append(ticker)
         test_data.append(d)
     for val in range (0,len(test_data),2):
         datacode = test_data[1 + val]
-        print (datacode,': ', smf_py.getMorningKey(ticker, datacode))
+        print (datacode,': ', smf_py.getMorningKey(ticker, datacode, exchange))
     sys.exit()
 
-def fin_test(smf_py, ticker, fin_type):
+def fin_test(smf_py, ticker, fin_type, exchange=None):
     test_data = []
     func_call = smf_py.getMorningFin
     if fin_type == 'qtr':
@@ -79,7 +86,7 @@ def fin_test(smf_py, ticker, fin_type):
         test_data.append(d)
     for val in range (0,len(test_data),2):
         datacode = test_data[1 + val]
-        print (datacode,': ', func_call(ticker, datacode))
+        print (datacode,': ', func_call(ticker, datacode, exchange))
     sys.exit()
 
 def yahoo_test(smf_py, ticker):
@@ -91,7 +98,7 @@ def yahoo_test(smf_py, ticker):
         datacode = test_data[1 + val]
         print (datacode,': ', smf_py.getYahoo(ticker, datacode))
     sys.exit()
-    
+
 def advfn_test(smf_py, ticker):
     test_data = []
     for d in range (1,5293):
@@ -102,15 +109,15 @@ def advfn_test(smf_py, ticker):
         datacode = test_data[1 + val]
         print (datacode,': ', smf_py.getADVFN(ticker, datacode))
     sys.exit()
-        
+
 def usage(err):
-    print ("Usage: smftest.py -f <function> -t <ticker>")
+    print ("Usage: smftest.py -f <function> -t <ticker> -e [exchange]")
     print ('Available functions are morningkey, morningfin, morningqfin, yahoo'
            'and advfn')
     if err == 2:
         sys.exit(2)
     else:
         sys.exit()
-        
+
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
Please take a look at my attempt to introduce support for optionally specifying the exchange.

The changes introduce a 3'rd optional exchange argument for the morning star functions. If specified, the function shall use the given argument. If it is not specified, the functional shall continue to use the original exchange lookup function. 

It is working on my PC. Let me know if you have any questions. 

**Note** I have reverted my changes from in compile.sh and Xsmf.idl from my other pull request so you can choose to take one, the other, both or neither. :)
