### PR TITLE
LibreOffice 5.3 compatibility

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
 #Import tools for compiling extension binaries
-export PATH=$PATH:/usr/lib/ure/bin/
-export PATH=$PATH:/usr/lib/libreoffice/sdk/bin/
+export PATH=$PATH:/opt/libreoffice5.3/sdk/bin/
 
 #Setup directories 
 mkdir "${PWD}"/SMF/
 mkdir "${PWD}"/SMF/META-INF/
 
 #Compile the binaries
-idlc "${PWD}"/idl/Xsmf.idl
+idlc -I /opt/libreoffice5.3/sdk/idl "${PWD}"/idl/Xsmf.idl
 regmerge -v "${PWD}"/SMF/Xsmf.rdb UCR "${PWD}"/idl/Xsmf.urd
 rm "${PWD}"/idl/Xsmf.urd
 

--- a/idl/Xsmf.idl
+++ b/idl/Xsmf.idl
@@ -1,4 +1,4 @@
-#include </usr/share/idl/libreoffice/com/sun/star/uno/XInterface.idl>
+#include </com/sun/star/uno/XInterface.idl>
 
 module com { module smf { module ticker { module getinfo {
 

--- a/src/generate_metainfo.py
+++ b/src/generate_metainfo.py
@@ -16,7 +16,7 @@ cur_dir = os.getcwd()
 
 # A unique ID for the extension.
 addin_id = "com.smf.ticker.getinfo"
-addin_version = "0.7.0"
+addin_version = "0.7.1"
 addin_displayname = "Stock Market Function Extension."
 addin_publisher_link = "https://github.com/madsailor/SMF-Extension"
 addin_publisher_name = "David Capron"

--- a/src/smftest.py
+++ b/src/smftest.py
@@ -15,13 +15,15 @@ import os
 import inspect
 import getopt
 #Add path to LO/OO components.
-if sys.version_info.major == 3:
-    sys.path.append('/usr/lib/libreoffice/program')
-else:
-    sys.path.append('/usr/lib/openoffice4/program')
-    if getattr(os.environ, 'URE_BOOTSTRAP', None) is None:
-        os.environ['URE_BOOTSTRAP'] = "vnd.sun.star.pathname:/usr/lib/"\
-                                      "openoffice4/program/fundamentalrc"
+#if sys.version_info.major == 3:
+#    sys.path.append('/usr/lib/libreoffice/program')
+#else:
+#    sys.path.append('/usr/lib/openoffice4/program')
+#    if getattr(os.environ, 'URE_BOOTSTRAP', None) is None:
+#        os.environ['URE_BOOTSTRAP'] = "vnd.sun.star.pathname:/usr/lib/"\
+#                                      "openoffice4/program/fundamentalrc"
+sys.path.append('/opt/libreoffice5.3/program')
+
 # Add current directory to path to import smf module
 cmd_folder = os.path.realpath(os.path.abspath
                               (os.path.split(inspect.getfile

--- a/src/yahoo.py
+++ b/src/yahoo.py
@@ -80,7 +80,7 @@ def cleanup_yahoo(self):
  
 def query_yahoo(self, ticker, stat):
     """Query Yahoo for the data we want""" 
-    url = 'http://finance.yahoo.com/d/quotes.csv?s=%s&f=%s' % (ticker, stat)
+    url = 'http://download.finance.yahoo.com/d/quotes.csv?s=%s&f=%s' % (ticker, stat)
     req = Request(url)
     try:
         response = urlopen(req)


### PR DESCRIPTION
Updated Yahoo URL and fixed paths for LibreOffice 5.3 extension creation.
Bumped version number since MASTER was 7 commits ahead of 0.7.0

This covers 2 existing issues:
#15 Yahoo URL changed
#18 idlc not finding include

plus updates paths for LibreOffice 5.3